### PR TITLE
Made it so users can add multiple dots per day and created optional delegate preliminaryView

### DIFF
--- a/CVCalendar Demo/CVCalendar Demo/ViewController.swift
+++ b/CVCalendar Demo/CVCalendar Demo/ViewController.swift
@@ -172,7 +172,7 @@ extension ViewController: CVCalendarViewDelegate {
         return false
     }
     
-    func dotMarker(colorOnDayView dayView: CVCalendarDayView) -> UIColor {
+    func dotMarker(colorOnDayView dayView: CVCalendarDayView) -> [UIColor] {
         let day = dayView.date.day
         
         let red = CGFloat(arc4random_uniform(600) / 255)
@@ -181,7 +181,15 @@ extension ViewController: CVCalendarViewDelegate {
         
         let color = UIColor(red: red, green: green, blue: blue, alpha: 1)
 
-        return color
+        let numberOfDots = Int(arc4random_uniform(3) + 1)
+        switch(numberOfDots) {
+        case 2:
+            return [color, color]
+        case 3:
+            return [color, color, color]
+        default:
+            return [color] // return 1 dot
+        }
     }
     
     func dotMarker(shouldMoveOnHighlightingOnDayView dayView: CVCalendarDayView) -> Bool {

--- a/CVCalendar Demo/CVCalendar Demo/ViewController.swift
+++ b/CVCalendar Demo/CVCalendar Demo/ViewController.swift
@@ -38,6 +38,21 @@ class ViewController: UIViewController {
 
 extension ViewController: CVCalendarViewDelegate
 {
+    func preliminaryView(viewOnDayView dayView: DayView) -> UIView
+    {
+        let circleView = CVAuxiliaryView(dayView: dayView, rect: dayView.bounds, shape: CVShape.Circle)
+        circleView.fillColor = .colorFromCode(0xCCCCCC)
+        return circleView
+    }
+    
+    func preliminaryView(shouldDisplayOnDayView dayView: DayView) -> Bool
+    {
+        if (dayView.isCurrentDay) {
+            return true
+        }
+        return false
+    }
+    
     func supplementaryView(viewOnDayView dayView: DayView) -> UIView
     {
         let π = M_PI

--- a/CVCalendar Demo/CVCalendar/CVCalendarDayView.swift
+++ b/CVCalendar Demo/CVCalendar/CVCalendarDayView.swift
@@ -50,6 +50,7 @@ class CVCalendarDayView: UIView {
             if oldValue != frame {
                 circleView?.setNeedsDisplay()
                 topMarkerSetup()
+                preliminarySetup()
                 supplementarySetup()
             }
         }
@@ -82,6 +83,7 @@ class CVCalendarDayView: UIView {
         topMarkerSetup()
         
         if (frame.width > 0) {
+            preliminarySetup()
             supplementarySetup()
         }
         
@@ -184,6 +186,15 @@ extension CVCalendarDayView {
         }
         
         addSubview(dayLabel!)
+    }
+
+    func preliminarySetup() {
+        if let delegate = calendarView.delegate, shouldShow = delegate.preliminaryView?(shouldDisplayOnDayView: self) where shouldShow {
+            if let preView = delegate.preliminaryView?(viewOnDayView: self) {
+                insertSubview(preView, atIndex: 0)
+                preView.layer.zPosition = CGFloat(-MAXFLOAT)
+            }
+        }
     }
     
     func supplementarySetup() {

--- a/CVCalendar Demo/CVCalendar/CVCalendarViewDelegate.swift
+++ b/CVCalendar Demo/CVCalendar/CVCalendarViewDelegate.swift
@@ -22,6 +22,9 @@ protocol CVCalendarViewDelegate {
     optional func dotMarker(colorOnDayView dayView: DayView) -> UIColor
     optional func dotMarker(moveOffsetOnDayView dayView: DayView) -> CGFloat
     
+    optional func preliminaryView(viewOnDayView dayView: DayView) -> UIView
+    optional func preliminaryView(shouldDisplayOnDayView dayView: DayView) -> Bool
+    
     optional func supplementaryView(viewOnDayView dayView: DayView) -> UIView
     optional func supplementaryView(shouldDisplayOnDayView dayView: DayView) -> Bool
 }

--- a/CVCalendar Demo/CVCalendar/CVCalendarViewDelegate.swift
+++ b/CVCalendar Demo/CVCalendar/CVCalendarViewDelegate.swift
@@ -19,7 +19,7 @@ protocol CVCalendarViewDelegate {
     optional func topMarker(shouldDisplayOnDayView dayView: DayView) -> Bool
     optional func dotMarker(shouldMoveOnHighlightingOnDayView dayView: DayView) -> Bool
     optional func dotMarker(shouldShowOnDayView dayView: DayView) -> Bool
-    optional func dotMarker(colorOnDayView dayView: DayView) -> UIColor
+    optional func dotMarker(colorOnDayView dayView: DayView) -> [UIColor]
     optional func dotMarker(moveOffsetOnDayView dayView: DayView) -> CGFloat
     
     optional func preliminaryView(viewOnDayView dayView: DayView) -> UIView


### PR DESCRIPTION
# Multiple Dots Per Day Description
Users can add up to 3 dots per day. I had to change the delegate dotMarker(colorOnDayView dayView: DayView) to return a [UIColor] instead of UIColor. This is because the dayView knows how many dots to add to the day based off of how many colors are returned in the array. Dots do not all need to be the same color on the day either.

![screen shot 2015-06-12 at 11 59 30 am](https://cloud.githubusercontent.com/assets/5099084/8134096/8c9ef290-10fa-11e5-8932-70f9d26e3dc0.png)

![screen shot 2015-06-12 at 11 38 58 am](https://cloud.githubusercontent.com/assets/5099084/8133681/c1549538-10f7-11e5-9896-5dd5bd1875df.png)

![screen shot 2015-06-12 at 11 39 06 am](https://cloud.githubusercontent.com/assets/5099084/8133688/c57d9538-10f7-11e5-87fe-3e7370b55c99.png)

# Preliminary View Commit Description
The optional delegate preliminaryView is basically a view that everything goes over (the dayLabel, the circleView, the supplementaryView). It works the same way supplementaryView works, but is useful for if users want to always have a circle around the present day (or any day). It' something I needed for my application, and I'm sure other users will find use in this too.

Here are some images that illustrate what it does:

When june 11 (which is the current day) is not the selected day
![screen shot 2015-06-11 at 12 43 50 pm](https://cloud.githubusercontent.com/assets/5099084/8112751/f7b31a20-1037-11e5-8684-b69f4212cb67.png)

When june 11 is the selected day
![screen shot 2015-06-11 at 12 43 57 pm](https://cloud.githubusercontent.com/assets/5099084/8112718/aa260fc4-1037-11e5-9270-0c1231cde4ef.png)