### PR TITLE
Added the ability to change the weekday symbol type for the CVCalendarMenu

### DIFF
--- a/CVCalendar Demo/CVCalendar Demo.xcodeproj/project.pbxproj
+++ b/CVCalendar Demo/CVCalendar Demo.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		8F6D3F1E1ADAF1330028BE6D /* CVCalendarWeekContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F6D3F1D1ADAF1330028BE6D /* CVCalendarWeekContentViewController.swift */; };
 		8F827D071ABF682B005294B1 /* CVAuxiliaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F827D061ABF682B005294B1 /* CVAuxiliaryView.swift */; };
 		8FDB51EF1AC09E0200F7F7AC /* CVShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FDB51EE1AC09E0200F7F7AC /* CVShape.swift */; };
+		E3EFB1891BC7315B00DEB189 /* CVWeekdaySymbolType.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3EFB1881BC7315B00DEB189 /* CVWeekdaySymbolType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -88,6 +89,7 @@
 		8F6D3F1D1ADAF1330028BE6D /* CVCalendarWeekContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVCalendarWeekContentViewController.swift; sourceTree = "<group>"; };
 		8F827D061ABF682B005294B1 /* CVAuxiliaryView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVAuxiliaryView.swift; sourceTree = "<group>"; };
 		8FDB51EE1AC09E0200F7F7AC /* CVShape.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVShape.swift; sourceTree = "<group>"; };
+		E3EFB1881BC7315B00DEB189 /* CVWeekdaySymbolType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVWeekdaySymbolType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -240,6 +242,7 @@
 				8F6D3F171ADAF0CA0028BE6D /* CVScrollDirection.swift */,
 				8F6993231ADE76F900D433FB /* CVCalendarWeekday.swift */,
 				8F6993211ADE716300D433FB /* CVCalendarViewPresentationMode.swift */,
+				E3EFB1881BC7315B00DEB189 /* CVWeekdaySymbolType.swift */,
 			);
 			name = Enums;
 			sourceTree = "<group>";
@@ -298,6 +301,7 @@
 		55E122101A588CB60013B002 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = GameApp;
 				TargetAttributes = {
@@ -382,6 +386,7 @@
 				8F1080BA1AB89CD400D9FAC6 /* CVRange.swift in Sources */,
 				55E122521A588CC50013B002 /* CVCalendarMenuView.swift in Sources */,
 				55E122581A588CC50013B002 /* CVCalendarViewAppearance.swift in Sources */,
+				E3EFB1891BC7315B00DEB189 /* CVWeekdaySymbolType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CVCalendar Demo/CVCalendar Demo/ViewController.swift
+++ b/CVCalendar Demo/CVCalendar Demo/ViewController.swift
@@ -138,6 +138,10 @@ extension ViewController: CVCalendarViewDelegate, CVCalendarMenuViewDelegate {
     func dotMarker(shouldMoveOnHighlightingOnDayView dayView: CVCalendarDayView) -> Bool {
         return true
     }
+    
+    func weekdaySymbolType() -> WeekdaySymbolType {
+        return .Short
+    }
 }
 
 // MARK: - CVCalendarViewDelegate

--- a/CVCalendar Demo/CVCalendar/CVCalendarMenuView.swift
+++ b/CVCalendar Demo/CVCalendar/CVCalendarMenuView.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 
+public typealias WeekdaySymbolType = CVWeekdaySymbolType
+
 public final class CVCalendarMenuView: UIView {
     public var symbols = [String]()
     public var symbolViews: [UILabel]?
@@ -16,6 +18,7 @@ public final class CVCalendarMenuView: UIView {
     public var dayOfWeekTextColor: UIColor? = .darkGrayColor()
     public var dayOfWeekTextUppercase: Bool? = true
     public var dayOfWeekFont: UIFont? = UIFont(name: "Avenir", size: 10)
+    public var weekdaySymbolType: WeekdaySymbolType? = .Short
 
     @IBOutlet public weak var menuViewDelegate: AnyObject? {
         set {
@@ -55,6 +58,7 @@ public final class CVCalendarMenuView: UIView {
             dayOfWeekTextColor~>delegate.dayOfWeekTextColor?()
             dayOfWeekTextUppercase~>delegate.dayOfWeekTextUppercase?()
             dayOfWeekFont~>delegate.dayOfWeekFont?()
+            weekdaySymbolType~>delegate.weekdaySymbolType?()
         }
     }
 
@@ -69,7 +73,16 @@ public final class CVCalendarMenuView: UIView {
     public func createDaySymbols() {
         // Change symbols with their places if needed.
         let dateFormatter = NSDateFormatter()
-        var weekdays = dateFormatter.shortWeekdaySymbols as NSArray
+        var weekdays: NSArray
+        
+        switch weekdaySymbolType! {
+        case .Normal:
+            weekdays = dateFormatter.weekdaySymbols as NSArray
+        case .Short:
+            weekdays = dateFormatter.shortWeekdaySymbols as NSArray
+        case .VeryShort:
+            weekdays = dateFormatter.veryShortWeekdaySymbols as NSArray
+        }
 
         let firstWeekdayIndex = firstWeekday!.rawValue - 1
         if (firstWeekdayIndex > 0) {

--- a/CVCalendar Demo/CVCalendar/CVCalendarMenuViewDelegate.swift
+++ b/CVCalendar Demo/CVCalendar/CVCalendarMenuViewDelegate.swift
@@ -15,4 +15,5 @@ public protocol CVCalendarMenuViewDelegate {
     optional func dayOfWeekTextColor() -> UIColor
     optional func dayOfWeekTextUppercase() -> Bool
     optional func dayOfWeekFont() -> UIFont
+    optional func weekdaySymbolType() -> WeekdaySymbolType
 }

--- a/CVCalendar Demo/CVCalendar/CVWeekdaySymbolType.swift
+++ b/CVCalendar Demo/CVCalendar/CVWeekdaySymbolType.swift
@@ -1,0 +1,15 @@
+//
+//  CVWeekdaySymbolType.swift
+//  CVCalendar Demo
+//
+//  Created by Roy McKenzie on 10/8/15.
+//  Copyright (c) 2015 GameApp. All rights reserved.
+//
+
+import Foundation
+
+@objc public enum CVWeekdaySymbolType: Int {
+    case Normal
+    case Short
+    case VeryShort
+}

--- a/CVCalendar/CVCalendarMenuView.swift
+++ b/CVCalendar/CVCalendarMenuView.swift
@@ -8,6 +8,8 @@
 
 import UIKit
 
+public typealias WeekdaySymbolType = CVWeekdaySymbolType
+
 public final class CVCalendarMenuView: UIView {
     public var symbols = [String]()
     public var symbolViews: [UILabel]?
@@ -16,6 +18,7 @@ public final class CVCalendarMenuView: UIView {
     public var dayOfWeekTextColor: UIColor? = .darkGrayColor()
     public var dayOfWeekTextUppercase: Bool? = true
     public var dayOfWeekFont: UIFont? = UIFont(name: "Avenir", size: 10)
+    public var weekdaySymbolType: WeekdaySymbolType? = .Short
 
     @IBOutlet public weak var menuViewDelegate: AnyObject? {
         set {
@@ -55,6 +58,7 @@ public final class CVCalendarMenuView: UIView {
             dayOfWeekTextColor~>delegate.dayOfWeekTextColor?()
             dayOfWeekTextUppercase~>delegate.dayOfWeekTextUppercase?()
             dayOfWeekFont~>delegate.dayOfWeekFont?()
+            weekdaySymbolType~>delegate.weekdaySymbolType?()
         }
     }
 
@@ -69,8 +73,17 @@ public final class CVCalendarMenuView: UIView {
     public func createDaySymbols() {
         // Change symbols with their places if needed.
         let dateFormatter = NSDateFormatter()
-        var weekdays = dateFormatter.shortWeekdaySymbols as NSArray
-
+        var weekdays: NSArray
+        
+        switch weekdaySymbolType! {
+        case .Normal:
+            weekdays = dateFormatter.weekdaySymbols as NSArray
+        case .Short:
+            weekdays = dateFormatter.shortWeekdaySymbols as NSArray
+        case .VeryShort:
+            weekdays = dateFormatter.veryShortWeekdaySymbols as NSArray
+        }
+        
         let firstWeekdayIndex = firstWeekday!.rawValue - 1
         if (firstWeekdayIndex > 0) {
             let copy = weekdays

--- a/CVCalendar/CVCalendarMenuViewDelegate.swift
+++ b/CVCalendar/CVCalendarMenuViewDelegate.swift
@@ -15,4 +15,5 @@ public protocol CVCalendarMenuViewDelegate {
     optional func dayOfWeekTextColor() -> UIColor
     optional func dayOfWeekTextUppercase() -> Bool
     optional func dayOfWeekFont() -> UIFont
+    optional func weekdaySymbolType() -> WeekdaySymbolType
 }

--- a/CVCalendar/CVWeekdaySymbolType.swift
+++ b/CVCalendar/CVWeekdaySymbolType.swift
@@ -1,0 +1,15 @@
+//
+//  CVWeekdaySymbolType.swift
+//  CVCalendar Demo
+//
+//  Created by Roy McKenzie on 10/8/15.
+//  Copyright (c) 2015 GameApp. All rights reserved.
+//
+
+import Foundation
+
+@objc public enum CVWeekdaySymbolType: Int {
+    case Normal
+    case Short
+    case VeryShort
+}


### PR DESCRIPTION
Hello, all! First pull request here. Would like to add the ability to change the weekday symbol type for the Calendar Menu. Uses an enum to allow easy selection. Selection is made on the delegate for CVCalendarMenuViewDelegate. 🖖🏻