### PR TITLE
Adds delegate methods to turn off the auto selection on month/week change.

### DIFF
--- a/CVCalendar Demo/CVCalendar/CVCalendarDayView.swift
+++ b/CVCalendar Demo/CVCalendar/CVCalendarDayView.swift
@@ -163,7 +163,7 @@ extension CVCalendarDayView {
             color = appearance.dayLabelWeekdayOutTextColor
         } else if isCurrentDay {
             let coordinator = calendarView.coordinator
-            if coordinator.selectedDayView == nil {
+            if coordinator.selectedDayView == nil && calendarView.shouldAutoSelectDayOnMonthChange {
                 let touchController = calendarView.touchController
                 touchController.receiveTouchOnDayView(self)
                 calendarView.didSelectDayView(self)

--- a/CVCalendar Demo/CVCalendar/CVCalendarMonthContentViewController.swift
+++ b/CVCalendar Demo/CVCalendar/CVCalendarMonthContentViewController.swift
@@ -37,7 +37,7 @@ public final class CVCalendarMonthContentViewController: CVCalendarContentViewCo
         insertMonthView(getFollowingMonth(date), withIdentifier: Following)
         
         presentedMonthView.mapDayViews { dayView in
-            if self.matchedDays(dayView.date, Date(date: date)) {
+            if self.calendarView.shouldAutoSelectDayOnMonthChange && self.matchedDays(dayView.date, Date(date: date)) {
                 self.calendarView.coordinator.flush()
                 self.calendarView.touchController.receiveTouchOnDayView(dayView)
                 dayView.circleView?.removeFromSuperview()
@@ -336,7 +336,7 @@ extension CVCalendarMonthContentViewController {
             self.presentedMonthView = presentedMonthView
             calendarView.presentedDate = Date(date: presentedMonthView.date)
             
-            if let selected = coordinator.selectedDayView, let selectedMonthView = selected.monthView where !matchedMonths(Date(date: selectedMonthView.date), Date(date: presentedMonthView.date)) {
+            if let selected = coordinator.selectedDayView, let selectedMonthView = selected.monthView where !matchedMonths(Date(date: selectedMonthView.date), Date(date: presentedMonthView.date)) && calendarView.shouldAutoSelectDayOnMonthChange {
                 let current = Date(date: NSDate())
                 let presented = Date(date: presentedMonthView.date)
                 

--- a/CVCalendar Demo/CVCalendar/CVCalendarView.swift
+++ b/CVCalendar Demo/CVCalendar/CVCalendarView.swift
@@ -80,6 +80,24 @@ public final class CVCalendarView: UIView {
         }
     }
     
+    public var shouldAutoSelectDayOnMonthChange: Bool{
+        get {
+            if let delegate = delegate, should = delegate.shouldAutoSelectDayOnMonthChange?() {
+                return should
+            }
+            return true
+        }
+    }
+    
+    public var shouldAutoSelectDayOnWeekChange: Bool{
+        get {
+            if let delegate = delegate, should = delegate.shouldAutoSelectDayOnWeekChange?() {
+                return should
+            }
+            return true
+        }
+    }
+    
     // MARK: - Calendar View Delegate
     
     @IBOutlet public weak var calendarDelegate: AnyObject? {

--- a/CVCalendar Demo/CVCalendar/CVCalendarViewDelegate.swift
+++ b/CVCalendar Demo/CVCalendar/CVCalendarViewDelegate.swift
@@ -18,6 +18,8 @@ public protocol CVCalendarViewDelegate {
     */
     optional func shouldAnimateResizing() -> Bool
     
+    optional func shouldAutoSelectDayOnWeekChange() -> Bool
+    optional func shouldAutoSelectDayOnMonthChange() -> Bool
     optional func shouldShowWeekdaysOut() -> Bool
     optional func didSelectDayView(dayView: DayView)
     optional func presentedDateUpdated(date: Date)

--- a/CVCalendar Demo/CVCalendar/CVCalendarWeekContentViewController.swift
+++ b/CVCalendar Demo/CVCalendar/CVCalendarWeekContentViewController.swift
@@ -43,8 +43,10 @@ public final class CVCalendarWeekContentViewController: CVCalendarContentViewCon
             if self.matchedDays(dayView.date, Date(date: date)) {
                 self.insertWeekView(dayView.weekView, withIdentifier: self.Presented)
                 self.calendarView.coordinator.flush()
-                self.calendarView.touchController.receiveTouchOnDayView(dayView)
-                dayView.circleView?.removeFromSuperview()
+                if self.calendarView.shouldAutoSelectDayOnWeekChange{
+                    self.calendarView.touchController.receiveTouchOnDayView(dayView)
+                    dayView.circleView?.removeFromSuperview()
+                }
             }
         }
         
@@ -407,7 +409,7 @@ extension CVCalendarWeekContentViewController {
                 }
             }
             
-            if let selected = coordinator.selectedDayView where !matchedWeeks(selected.date, presentedDate) {
+            if let selected = coordinator.selectedDayView where !matchedWeeks(selected.date, presentedDate) && calendarView.shouldAutoSelectDayOnWeekChange {
                 let current = Date(date: NSDate())
                 
                 if matchedWeeks(current, presentedDate) {


### PR DESCRIPTION
Added two delegate methods to let the user turn off the auto-selection (and subsequent calls to didSelectDayView) of the first day on month/week change. The default behavior is not altered in any way to avoid breaking existing implementations. 