### PR TITLE
Adds a delegate method to prevent scrolling to the previous/next view on selection

### DIFF
--- a/CVCalendar Demo/CVCalendar/CVCalendarMonthContentViewController.swift
+++ b/CVCalendar Demo/CVCalendar/CVCalendarMonthContentViewController.swift
@@ -129,7 +129,7 @@ public final class CVCalendarMonthContentViewController: CVCalendarContentViewCo
     }
     
     public override func performedDayViewSelection(dayView: DayView) {
-        if dayView.isOut {
+        if dayView.isOut && calendarView.shouldScrollOnOutDayViewSelection {
             if dayView.date.day > 20 {
                 let presentedDate = dayView.monthView.date
                 calendarView.presentedDate = Date(date: self.dateBeforeDate(presentedDate))

--- a/CVCalendar Demo/CVCalendar/CVCalendarView.swift
+++ b/CVCalendar Demo/CVCalendar/CVCalendarView.swift
@@ -98,6 +98,15 @@ public final class CVCalendarView: UIView {
         }
     }
     
+    public var shouldScrollOnOutDayViewSelection: Bool{
+        get {
+            if let delegate = delegate, should = delegate.shouldScrollOnOutDayViewSelection?() {
+                return should
+            }
+            return true
+        }
+    }
+    
     // MARK: - Calendar View Delegate
     
     @IBOutlet public weak var calendarDelegate: AnyObject? {

--- a/CVCalendar Demo/CVCalendar/CVCalendarViewDelegate.swift
+++ b/CVCalendar Demo/CVCalendar/CVCalendarViewDelegate.swift
@@ -18,6 +18,7 @@ public protocol CVCalendarViewDelegate {
     */
     optional func shouldAnimateResizing() -> Bool
     
+    optional func shouldScrollOnOutDayViewSelection() -> Bool
     optional func shouldAutoSelectDayOnWeekChange() -> Bool
     optional func shouldAutoSelectDayOnMonthChange() -> Bool
     optional func shouldShowWeekdaysOut() -> Bool

--- a/CVCalendar Demo/CVCalendar/CVCalendarWeekContentViewController.swift
+++ b/CVCalendar Demo/CVCalendar/CVCalendarWeekContentViewController.swift
@@ -132,7 +132,7 @@ public final class CVCalendarWeekContentViewController: CVCalendarContentViewCon
     }
     
     public override func performedDayViewSelection(dayView: DayView) {
-        if dayView.isOut {
+        if dayView.isOut && calendarView.shouldScrollOnOutDayViewSelection {
             if dayView.date.day > 20 {
                 let presentedDate = dayView.monthView.date
                 calendarView.presentedDate = Date(date: self.dateBeforeDate(presentedDate))

--- a/CVCalendar/CVCalendarMonthContentViewController.swift
+++ b/CVCalendar/CVCalendarMonthContentViewController.swift
@@ -129,7 +129,7 @@ public final class CVCalendarMonthContentViewController: CVCalendarContentViewCo
     }
     
     public override func performedDayViewSelection(dayView: DayView) {
-        if dayView.isOut {
+        if dayView.isOut && calendarView.shouldScrollOnOutDayViewSelection {
             if dayView.date.day > 20 {
                 let presentedDate = dayView.monthView.date
                 calendarView.presentedDate = Date(date: self.dateBeforeDate(presentedDate))

--- a/CVCalendar/CVCalendarView.swift
+++ b/CVCalendar/CVCalendarView.swift
@@ -98,6 +98,15 @@ public final class CVCalendarView: UIView {
         }
     }
     
+    public var shouldScrollOnOutDayViewSelection: Bool{
+        get {
+            if let delegate = delegate, should = delegate.shouldScrollOnOutDayViewSelection?() {
+                return should
+            }
+            return true
+        }
+    }
+    
     // MARK: - Calendar View Delegate
     
     @IBOutlet public weak var calendarDelegate: AnyObject? {

--- a/CVCalendar/CVCalendarViewDelegate.swift
+++ b/CVCalendar/CVCalendarViewDelegate.swift
@@ -18,6 +18,7 @@ public protocol CVCalendarViewDelegate {
     */
     optional func shouldAnimateResizing() -> Bool
     
+    optional func shouldScrollOnOutDayViewSelection() -> Bool
     optional func shouldAutoSelectDayOnWeekChange() -> Bool
     optional func shouldAutoSelectDayOnMonthChange() -> Bool
     optional func shouldShowWeekdaysOut() -> Bool

--- a/CVCalendar/CVCalendarWeekContentViewController.swift
+++ b/CVCalendar/CVCalendarWeekContentViewController.swift
@@ -132,7 +132,7 @@ public final class CVCalendarWeekContentViewController: CVCalendarContentViewCon
     }
     
     public override func performedDayViewSelection(dayView: DayView) {
-        if dayView.isOut {
+        if dayView.isOut && calendarView.shouldScrollOnOutDayViewSelection {
             if dayView.date.day > 20 {
                 let presentedDate = dayView.monthView.date
                 calendarView.presentedDate = Date(date: self.dateBeforeDate(presentedDate))


### PR DESCRIPTION
Some users may want to restrict the auto-scrolling to the previous / next month, but still maintain the ability to manually scroll (either by calling the loadNextView or dragging). This PR adds a delegate method to lock the scrolling when an 'out' dayView gets selected. I've updated both sets of files (demo & root level)