### PR TITLE
Fix to avoid crash on setup dot markers

### DIFF
--- a/CVCalendar Demo/CVCalendar/CVCalendarDayView.swift
+++ b/CVCalendar Demo/CVCalendar/CVCalendarDayView.swift
@@ -246,6 +246,8 @@ extension CVCalendarDayView {
             dotMarkers[index] = nil
         }
         
+        dotMarkers.removeAll()
+        
         if let delegate = calendarView.delegate {
             if let shouldShow = delegate.dotMarker?(shouldShowOnDayView: self) where shouldShow {
                 

--- a/CVCalendar/CVCalendarDayView.swift
+++ b/CVCalendar/CVCalendarDayView.swift
@@ -241,10 +241,10 @@ extension CVCalendarDayView {
     }
     
     public func setupDotMarker() {
-        for (index, dotMarker) in dotMarkers.enumerate() {
+        for (dotMarker) in dotMarkers.enumerate() {
             dotMarker!.removeFromSuperview()
-            dotMarkers[index] = nil
         }
+        dotMarkers.removeAll()
         
         if let delegate = calendarView.delegate {
             if let shouldShow = delegate.dotMarker?(shouldShowOnDayView: self) where shouldShow {


### PR DESCRIPTION
If you have removed a mark from a day and call `setupDotMarker` in order to setup a new one, the previous mark index remains in the `dotMarkers` array but it's `nil`. So we need to remove all marks from array before adding new ones in the `setupDotMarker`.