### PR TITLE
Fixed colouring for more than one dot marker after unhighlighting day

### DIFF
--- a/CVCalendar Demo/CVCalendar/CVCalendarDayView.swift
+++ b/CVCalendar Demo/CVCalendar/CVCalendarDayView.swift
@@ -306,6 +306,7 @@ extension CVCalendarDayView {
 extension CVCalendarDayView {
     public func moveDotMarkerBack(unwinded: Bool, coloring: Bool) {
         var coloring = coloring
+        var dotIndex = 0
         for dotMarker in dotMarkers {
             if let calendarView = calendarView, let dotMarker = dotMarker {
                 var shouldMove = true
@@ -322,7 +323,7 @@ extension CVCalendarDayView {
                         if unwinded {
                             if let myColor = delegate.dotMarker?(colorOnDayView: self) {
                                 color = isOut ?
-                                    appearance.dayLabelWeekdayOutTextColor : myColor.first
+                                    appearance.dayLabelWeekdayOutTextColor : myColor[dotIndex]
                             }
                         } else {
                             color = appearance.dotMarkerColor
@@ -374,6 +375,7 @@ extension CVCalendarDayView {
                 } else {
                     colorMarker()
                 }
+                dotIndex += 1
             }
         }
     }

--- a/CVCalendar/CVCalendarDayView.swift
+++ b/CVCalendar/CVCalendarDayView.swift
@@ -306,6 +306,7 @@ extension CVCalendarDayView {
 extension CVCalendarDayView {
     public func moveDotMarkerBack(unwinded: Bool, coloring: Bool) {
         var coloring = coloring
+        var dotIndex = 0
         for dotMarker in dotMarkers {
             if let calendarView = calendarView, let dotMarker = dotMarker {
                 var shouldMove = true
@@ -322,7 +323,7 @@ extension CVCalendarDayView {
                         if unwinded {
                             if let myColor = delegate.dotMarker?(colorOnDayView: self) {
                                 color = isOut ?
-                                    appearance.dayLabelWeekdayOutTextColor : myColor.first
+                                    appearance.dayLabelWeekdayOutTextColor : myColor[dotIndex]
                             }
                         } else {
                             color = appearance.dotMarkerColor
@@ -374,6 +375,7 @@ extension CVCalendarDayView {
                 } else {
                     colorMarker()
                 }
+                dotIndex += 1
             }
         }
     }


### PR DESCRIPTION
Previously all markers for one day got colour of the first dot marker after selecting other day.