### PR TITLE
Customize duration of date selection animation

### DIFF
--- a/CVCalendar/CVCalendarContentViewController.swift
+++ b/CVCalendar/CVCalendarContentViewController.swift
@@ -36,6 +36,10 @@ public class CVCalendarContentViewController: UIViewController {
     public var presentationEnabled = true
     public var lastContentOffset: CGFloat = 0
     public var direction: CVScrollDirection = .None
+  
+    public var toggleDateAnimationDuration: Double {
+        return calendarView.delegate?.toggleDateAnimationDuration?() ?? 0.8
+    }
 
     public init(calendarView: CalendarView, frame: CGRect) {
         self.calendarView = calendarView

--- a/CVCalendar/CVCalendarMonthContentViewController.swift
+++ b/CVCalendar/CVCalendarMonthContentViewController.swift
@@ -253,7 +253,7 @@ public final class CVCalendarMonthContentViewController: CVCalendarContentViewCo
 
                 calendarView.presentedDate = Date(date: date)
 
-                UIView.animateWithDuration(0.8, delay: 0,
+                UIView.animateWithDuration(toggleDateAnimationDuration, delay: 0,
                                            options: UIViewAnimationOptions.CurveEaseInOut,
                                            animations: {
                     presentedMonth.alpha = 0

--- a/CVCalendar/CVCalendarViewDelegate.swift
+++ b/CVCalendar/CVCalendarViewDelegate.swift
@@ -17,6 +17,7 @@ public protocol CVCalendarViewDelegate {
     Determines whether resizing should cause related views' animation.
     */
     optional func shouldAnimateResizing() -> Bool
+    optional func toggleDateAnimationDuration() -> Double
 
     optional func shouldScrollOnOutDayViewSelection() -> Bool
     optional func shouldAutoSelectDayOnWeekChange() -> Bool

--- a/CVCalendar/CVCalendarWeekContentViewController.swift
+++ b/CVCalendar/CVCalendarWeekContentViewController.swift
@@ -259,7 +259,7 @@ public final class CVCalendarWeekContentViewController: CVCalendarContentViewCon
                 insertWeekView(currentWeekView, withIdentifier: presented)
                 insertWeekView(getFollowingWeek(currentWeekView), withIdentifier: following)
 
-                UIView.animateWithDuration(0.8, delay: 0,
+                UIView.animateWithDuration(toggleDateAnimationDuration, delay: 0,
                                            options: UIViewAnimationOptions.CurveEaseInOut,
                                            animations: {
                     presentedWeekView.alpha = 0


### PR DESCRIPTION
`0.8` seconds look too slow for date selection animation so I introduced a new method on `CVCalendarViewDelegate` called `toggleDateAnimationDuration` for letting user customize that.

PTAL @Mozharovsky  @elsesiy 