### PR TITLE
Issue #337, "Change the month and the app goes in crash!"

### DIFF
--- a/CVCalendar/CVCalendarDayView.swift
+++ b/CVCalendar/CVCalendarDayView.swift
@@ -52,7 +52,9 @@ public final class CVCalendarDayView: UIView {
                 selectionView?.setNeedsDisplay()
                 topMarkerSetup()
                 preliminarySetup()
-                supplementarySetup()
+								if date != nil {
+										supplementarySetup()
+								}
             }
         }
     }


### PR DESCRIPTION
I just moved condition (if date != nil ... ) from Demo Project

..thanks a lot to  @nremarck

was like this:
`public override var frame: CGRect {
        didSet {
            if oldValue != frame {
                selectionView?.setNeedsDisplay()
                topMarkerSetup()
                preliminarySetup()
                **supplementarySetup()**
            }
        }
    }
`
it is now:
`public override var frame: CGRect {
        didSet {
            if oldValue != frame {
                selectionView?.setNeedsDisplay()
                topMarkerSetup()
                preliminarySetup()
		**if date != nil {
			supplementarySetup()
		}**
            }
        }
    }
`