### PR TITLE
Remove unnecessary get keyword

### DIFF
--- a/CVCalendar/CVAuxiliaryView.swift
+++ b/CVCalendar/CVAuxiliaryView.swift
@@ -25,9 +25,7 @@ public final class CVAuxiliaryView: UIView {
     public let defaultFillColor = UIColor.colorFromCode(0xe74c3c)
 
     fileprivate var radius: CGFloat {
-        get {
-            return (min(frame.height, frame.width) - 10) / 2
-        }
+        return (min(frame.height, frame.width) - 10) / 2
     }
 
     public unowned let dayView: DayView

--- a/CVCalendar/CVCalendarContentViewController.swift
+++ b/CVCalendar/CVCalendarContentViewController.swift
@@ -27,9 +27,7 @@ open class CVCalendarContentViewController: UIViewController {
 
     open var currentPage = 1
     open var pageChanged: Bool {
-        get {
-            return currentPage == 1 ? false : true
-        }
+        return currentPage == 1 ? false : true
     }
 
     open var pageLoadingEnabled = true

--- a/CVCalendar/CVCalendarDayView.swift
+++ b/CVCalendar/CVCalendarDayView.swift
@@ -25,25 +25,21 @@ public final class CVCalendarDayView: UIView {
     public var isDisabled: Bool { return !self.isUserInteractionEnabled }
 
     public weak var monthView: CVCalendarMonthView! {
-        get {
-            var monthView: MonthView!
-            if let weekView = weekView, let activeMonthView = weekView.monthView {
-                monthView = activeMonthView
-            }
-
-            return monthView
+        var monthView: MonthView!
+        if let weekView = weekView, let activeMonthView = weekView.monthView {
+            monthView = activeMonthView
         }
+
+        return monthView
     }
 
     public weak var calendarView: CVCalendarView! {
-        get {
-            var calendarView: CVCalendarView!
-            if let weekView = weekView, let activeCalendarView = weekView.calendarView {
-                calendarView = activeCalendarView
-            }
-
-            return calendarView
+        var calendarView: CVCalendarView!
+        if let weekView = weekView, let activeCalendarView = weekView.calendarView {
+            calendarView = activeCalendarView
         }
+
+        return calendarView
     }
 
     public override var frame: CGRect {

--- a/CVCalendar/CVCalendarDayViewControlCoordinator.swift
+++ b/CVCalendar/CVCalendarDayViewControlCoordinator.swift
@@ -16,9 +16,7 @@ public final class CVCalendarDayViewControlCoordinator {
     // MARK: - Public properties
     public weak var selectedDayView: CVCalendarDayView?
     public var animator: CVCalendarViewAnimator! {
-        get {
-            return calendarView.animator
-        }
+        return calendarView.animator
     }
 
     // MARK: - initialization

--- a/CVCalendar/CVCalendarMonthView.swift
+++ b/CVCalendar/CVCalendarMonthView.swift
@@ -38,12 +38,10 @@ public final class CVCalendarMonthView: UIView {
     public var currentDay: Int?
 
     public var potentialSize: CGSize {
-        get {
-            return CGSize(width: bounds.width,
-                          height: CGFloat(weekViews.count) * weekViews[0].bounds.height +
-                            calendarView.appearance.spaceBetweenWeekViews! *
-                            CGFloat(weekViews.count))
-        }
+        return CGSize(width: bounds.width,
+                      height: CGFloat(weekViews.count) * weekViews[0].bounds.height +
+                        calendarView.appearance.spaceBetweenWeekViews! *
+                        CGFloat(weekViews.count))
     }
 
     // MARK: - Initialization

--- a/CVCalendar/CVCalendarTouchController.swift
+++ b/CVCalendar/CVCalendarTouchController.swift
@@ -13,9 +13,7 @@ public final class CVCalendarTouchController {
 
     // MARK: - Properties
     public var coordinator: Coordinator {
-        get {
-            return calendarView.coordinator
-        }
+        return calendarView.coordinator
     }
 
     // Init.

--- a/CVCalendar/CVCalendarView.swift
+++ b/CVCalendar/CVCalendarView.swift
@@ -44,12 +44,10 @@ public final class CVCalendarView: UIView {
     fileprivate var validated = false
 
     public var firstWeekday: Weekday {
-        get {
-            if let delegate = delegate {
-                return delegate.firstWeekday()
-            } else {
-                return .sunday
-            }
+        if let delegate = delegate {
+            return delegate.firstWeekday()
+        } else {
+            return .sunday
         }
     }
 
@@ -70,40 +68,32 @@ public final class CVCalendarView: UIView {
     }
 
     public var shouldAnimateResizing: Bool {
-        get {
-            if let delegate = delegate, let should = delegate.shouldAnimateResizing?() {
-                return should
-            }
-
-            return true
+        if let delegate = delegate, let should = delegate.shouldAnimateResizing?() {
+            return should
         }
+        
+        return true
     }
-
+    
     public var shouldAutoSelectDayOnMonthChange: Bool {
-        get {
-            if let delegate = delegate, let should = delegate.shouldAutoSelectDayOnMonthChange?() {
-                return should
-            }
-            return true
+        if let delegate = delegate, let should = delegate.shouldAutoSelectDayOnMonthChange?() {
+            return should
         }
+        return true
     }
 
     public var shouldAutoSelectDayOnWeekChange: Bool {
-        get {
-            if let delegate = delegate, let should = delegate.shouldAutoSelectDayOnWeekChange?() {
-                return should
-            }
-            return true
+        if let delegate = delegate, let should = delegate.shouldAutoSelectDayOnWeekChange?() {
+            return should
         }
+        return true
     }
-
+    
     public var shouldScrollOnOutDayViewSelection: Bool {
-        get {
-            if let delegate = delegate, let should = delegate.shouldScrollOnOutDayViewSelection?() {
-                return should
-            }
-            return true
+        if let delegate = delegate, let should = delegate.shouldScrollOnOutDayViewSelection?() {
+            return should
         }
+        return true
     }
 
     // MARK: - Calendar View Delegate

--- a/CVCalendar/CVCalendarViewAnimator.swift
+++ b/CVCalendar/CVCalendarViewAnimator.swift
@@ -14,9 +14,7 @@ public final class CVCalendarViewAnimator {
     // MARK: - Public properties
     public weak var delegate: CVCalendarViewAnimatorDelegate!
     public var coordinator: CVCalendarDayViewControlCoordinator {
-        get {
-            return calendarView.coordinator
-        }
+        return calendarView.coordinator
     }
 
     // MARK: - Init

--- a/CVCalendar/CVCalendarWeekView.swift
+++ b/CVCalendar/CVCalendarWeekView.swift
@@ -48,14 +48,12 @@ public final class CVCalendarWeekView: UIView {
     public var utilizable = false /// Recovery service.
 
     public weak var calendarView: CVCalendarView! {
-        get {
-            var calendarView: CVCalendarView!
-            if let monthView = monthView, let activeCalendarView = monthView.calendarView {
-                calendarView = activeCalendarView
-            }
-
-            return calendarView
+        var calendarView: CVCalendarView!
+        if let monthView = monthView, let activeCalendarView = monthView.calendarView {
+            calendarView = activeCalendarView
         }
+        
+        return calendarView
     }
 
     // MARK: - Initialization

--- a/CVCalendar/CVDate.swift
+++ b/CVCalendar/CVDate.swift
@@ -65,17 +65,13 @@ extension CVDate {
 
 extension CVDate {
     public var globalDescription: String {
-        get {
-            let month = dateFormattedStringWithFormat("MMMM", fromDate: date)
-            return "\(month), \(year)"
-        }
+        let month = dateFormattedStringWithFormat("MMMM", fromDate: date)
+        return "\(month), \(year)"
     }
 
     public var commonDescription: String {
-        get {
-            let month = dateFormattedStringWithFormat("MMMM", fromDate: date)
-            return "\(day) \(month), \(year)"
-        }
+        let month = dateFormattedStringWithFormat("MMMM", fromDate: date)
+        return "\(day) \(month), \(year)"
     }
 }
 

--- a/CVCalendar/CVScrollDirection.swift
+++ b/CVCalendar/CVScrollDirection.swift
@@ -14,12 +14,10 @@ public enum CVScrollDirection {
     case left
 
     var description: String {
-        get {
-            switch self {
-            case .left: return "Left"
-            case .right: return "Right"
-            case .none: return "None"
-            }
+        switch self {
+        case .left: return "Left"
+        case .right: return "Right"
+        case .none: return "None"
         }
     }
 }

--- a/CVCalendar/CVSet.swift
+++ b/CVCalendar/CVSet.swift
@@ -32,12 +32,10 @@ public struct CVSet<T: AnyObject>: ExpressibleByNilLiteral {
 
     // MARK: - Subscript
     subscript(index: Int) -> T? {
-        get {
-            if index < storage.count {
-                return storage[index]
-            } else {
-                return nil
-            }
+        if index < storage.count {
+            return storage[index]
+        } else {
+            return nil
         }
     }
 }


### PR DESCRIPTION
***Read-Only Computed Properties*** is unnecessary for `get` keyword. so, I removed get keyword in read only computed properties.

Please refer to the [The Swift Programming Language / Properties](https://developer.apple.com/library/content/documentation/Swift/Conceptual/Swift_Programming_Language/Properties.html) for more information as to ***Read-Only Computed Properties***

> You can simplify the declaration of a read-only computed property by removing the get keyword and its braces:
