### PR TITLE
Replace constant toggling animation duration with the toggleDateAnimationDuration;

### DIFF
--- a/CVCalendar/CVCalendarMonthContentViewController.swift
+++ b/CVCalendar/CVCalendarMonthContentViewController.swift
@@ -253,7 +253,7 @@ public final class CVCalendarMonthContentViewController: CVCalendarContentViewCo
 
                 calendarView.presentedDate = CVDate(date: date)
 
-                UIView.animate(withDuration: 0.8, delay: 0,
+                UIView.animate(withDuration: toggleDateAnimationDuration, delay: 0,
                                            options: UIViewAnimationOptions(),
                                            animations: {
                     presentedMonth.alpha = 0

--- a/CVCalendar/CVCalendarWeekContentViewController.swift
+++ b/CVCalendar/CVCalendarWeekContentViewController.swift
@@ -259,7 +259,7 @@ public final class CVCalendarWeekContentViewController: CVCalendarContentViewCon
                 insertWeekView(currentWeekView, withIdentifier: presented)
                 insertWeekView(getFollowingWeek(currentWeekView), withIdentifier: following)
 
-                UIView.animate(withDuration: 0.8, delay: 0,
+                UIView.animate(withDuration: toggleDateAnimationDuration, delay: 0,
                                            options: UIViewAnimationOptions(),
                                            animations: {
                     presentedWeekView.alpha = 0


### PR DESCRIPTION
Hi there ✋ 

I've found that some methods don't use the `toggleDateAnimationDuration` to specify the toggling animation duration, but instead use the constant `0.8` seconds.

This PR fixes that one, and now every toggle related method is using the variable instead of constant 🚀 

@Mozharovsky please correct me if it was on purpose.