### PR TITLE
When the newly set presentedDate equals to the old presentedDate, presentedDate don’t update

### DIFF
--- a/CVCalendar/CVCalendarView.swift
+++ b/CVCalendar/CVCalendarView.swift
@@ -64,7 +64,9 @@ public final class CVCalendarView: UIView {
     public var presentedDate: CVDate! {
         didSet {
             if let _ = oldValue {
-                delegate?.presentedDateUpdated?(presentedDate)
+                if presentedDate.convertedDate(calendar: Calendar.current) != oldValue.convertedDate(calendar: Calendar.current) {
+                    delegate?.presentedDateUpdated?(presentedDate)
+                }
             }
         }
     }


### PR DESCRIPTION
When the newly set presentedDate equals to the old presentedDate, presentedDate don’t update