### PR TITLE
SupplementaryView-Demo-Standardization

### DIFF
--- a/CVCalendar Demo/CVCalendar Demo/ViewController.swift
+++ b/CVCalendar Demo/CVCalendar Demo/ViewController.swift
@@ -245,13 +245,36 @@ extension ViewController: CVCalendarViewDelegate, CVCalendarMenuViewDelegate {
     }
     
     func supplementaryView(shouldDisplayOnDayView dayView: DayView) -> Bool {
+      
+      guard let currentCalendar = currentCalendar else {
+        return false
+      }
+      var components = Manager.componentsForDate(Foundation.Date(), calendar: currentCalendar)
+      
+      /* For consistency, always show supplementaryView on the 3rd, 13th and 23rd of the current month/year.  This is to check that these expected calendar days are "circled". There was a bug that was circling the wrong dates. A fix was put in for #408 #411.
+       
+       Other month and years show random days being circled as was done previously in the Demo code.
+       */
+      
+      if dayView.date.year == components.year &&
+        dayView.date.month == components.month {
+        
+        if (dayView.date.day == 3 || dayView.date.day == 13 || dayView.date.day == 23)  {
+          print("Circle should apprear on " + dayView.date.commonDescription)
+          return true
+        }
+        return false
+      } else {
+        
         if (Int(arc4random_uniform(3)) == 1) {
-            return true
+          return true
         }
         
         return false
+      }
+      
     }
-    
+  
     func dayOfWeekTextColor() -> UIColor {
         return UIColor.white
     }


### PR DESCRIPTION
This change will display (circle) the supplementaryView on three
specific days in the current month/year.  The 3rd, 13th and 23rd, are
expected to be circled when launched.  Other months/years, show random
days displaying the supplementaryView as in previous demos.

Since a bug was found in the Demo that was “circling” the wrong dates,
this will ensure that future changes always show these three dates
circled in the Demo