### PR TITLE
Set proper day view text color during the initialization for current date;

### DIFF
--- a/CVCalendar/CVCalendarDayView.swift
+++ b/CVCalendar/CVCalendarDayView.swift
@@ -178,6 +178,7 @@ extension CVCalendarDayView {
                 let touchController = calendarView.touchController
                 touchController?.receiveTouchOnDayView(self)
                 calendarView.didSelectDayView(self)
+                color = appearance?.dayLabelPresentWeekdaySelectedTextColor
             } else {
                 color = appearance?.dayLabelPresentWeekdayTextColor
                 if (appearance?.dayLabelPresentWeekdayInitallyBold!)! {

--- a/CVCalendar/CVCalendarView.swift
+++ b/CVCalendar/CVCalendarView.swift
@@ -313,9 +313,9 @@ extension CVCalendarView {
 
 extension CVCalendarView {
     public func didSelectDayView(_ dayView: CVCalendarDayView) {
+        presentedDate = dayView.date
+        delegate?.didSelectDayView?(dayView, animationDidFinish: false)
         if let controller = contentController {
-            presentedDate = dayView.date
-            delegate?.didSelectDayView?(dayView, animationDidFinish: false)
             controller.performedDayViewSelection(dayView) // TODO: Update to range selection
         }
     }


### PR DESCRIPTION
In a `CVCalendarDayView` there is a method `public func labelSetup()` that set ups a dateLabel properties. However in case of currentDate and `shouldAutoSelectDayOnMonthChange` returns `true` the textColor of the label is `nil`, but the value from appearance must be used.