### PR TITLE
fix issue where 'out' dates still selectable when should be disabled

### DIFF
--- a/CVCalendar Demo/CVCalendar Demo.xcodeproj/project.pbxproj
+++ b/CVCalendar Demo/CVCalendar Demo.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		564E035F1D51DA100088B8D3 /* CVStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E03411D51DA100088B8D3 /* CVStatus.swift */; };
 		564E03601D51DA100088B8D3 /* CVWeekdaySymbolType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564E03421D51DA100088B8D3 /* CVWeekdaySymbolType.swift */; };
 		564E03611D51DA100088B8D3 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 564E03431D51DA100088B8D3 /* Info.plist */; };
+		AAAC86141E4E57C100D098DF /* CVCalendarContentPresentationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAC86131E4E57C100D098DF /* CVCalendarContentPresentationCoordinator.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -97,6 +98,7 @@
 		564E03411D51DA100088B8D3 /* CVStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVStatus.swift; sourceTree = "<group>"; };
 		564E03421D51DA100088B8D3 /* CVWeekdaySymbolType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVWeekdaySymbolType.swift; sourceTree = "<group>"; };
 		564E03431D51DA100088B8D3 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AAAC86131E4E57C100D098DF /* CVCalendarContentPresentationCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVCalendarContentPresentationCoordinator.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -196,6 +198,7 @@
 				564E03351D51DA100088B8D3 /* CVCalendarViewDelegate.swift */,
 				564E03361D51DA100088B8D3 /* CVCalendarViewPresentationMode.swift */,
 				564E03371D51DA100088B8D3 /* CVCalendarWeekContentViewController.swift */,
+				AAAC86131E4E57C100D098DF /* CVCalendarContentPresentationCoordinator.swift */,
 				564E03381D51DA100088B8D3 /* CVCalendarWeekday.swift */,
 				564E03391D51DA100088B8D3 /* CVCalendarWeekView.swift */,
 				564E033A1D51DA100088B8D3 /* CVDate.swift */,
@@ -340,6 +343,7 @@
 				564E03541D51DA100088B8D3 /* CVCalendarViewPresentationMode.swift in Sources */,
 				564E03501D51DA100088B8D3 /* CVCalendarViewAnimatorDelegate.swift in Sources */,
 				564E034C1D51DA100088B8D3 /* CVCalendarMonthView.swift in Sources */,
+				AAAC86141E4E57C100D098DF /* CVCalendarContentPresentationCoordinator.swift in Sources */,
 				564E03491D51DA100088B8D3 /* CVCalendarMenuView.swift in Sources */,
 				564E03561D51DA100088B8D3 /* CVCalendarWeekday.swift in Sources */,
 				564E034E1D51DA100088B8D3 /* CVCalendarView.swift in Sources */,

--- a/CVCalendar Demo/CVCalendar Demo/ViewController.swift
+++ b/CVCalendar Demo/CVCalendar Demo/ViewController.swift
@@ -349,15 +349,10 @@ extension ViewController: CVCalendarViewAppearanceDelegate {
 
 extension ViewController {
     @IBAction func switchChanged(sender: UISwitch) {
-        if sender.isOn {
-            calendarView.changeDaysOutShowingState(false)
-            shouldShowDaysOut = true
-        } else {
-            calendarView.changeDaysOutShowingState(true)
-            shouldShowDaysOut = false
-        }
+      calendarView.changeDaysOutShowingState(shouldShow: sender.isOn)
+      shouldShowDaysOut = sender.isOn
     }
-    
+  
     @IBAction func todayMonthView() {
         calendarView.toggleCurrentDayView()
     }

--- a/CVCalendar/CVCalendarContentPresentationCoordinator.swift
+++ b/CVCalendar/CVCalendarContentPresentationCoordinator.swift
@@ -1,0 +1,36 @@
+//
+//  CVCalendarContentViewPresentationCoordinator.swift
+//  CVCalendar Demo
+//
+//  Created by Ethan Setnik on 2/10/17.
+//  Copyright © 2017 GameApp. All rights reserved.
+//
+
+import UIKit
+protocol CVCalendarContentPresentationCoordinator {
+  func setDayOutViewsVisible(monthViews: [Identifier: MonthView], visible: Bool)
+}
+
+extension CVCalendarContentPresentationCoordinator {
+  public func setDayOutViewsVisible(monthViews: [Identifier: MonthView], visible: Bool) {
+    for monthView in monthViews.values {
+      monthView.mapDayViews { dayView in
+        if dayView.isOut {
+
+          if visible {
+            dayView.alpha = 0
+            dayView.isHidden = false
+          }
+
+          UIView.animate(withDuration: 0.5, delay: 0,
+                         options: UIViewAnimationOptions(),
+                         animations: {
+            dayView.alpha = visible ? 1 : 0
+          }, completion: { _ in
+            dayView.isHidden = !visible
+          })
+        }
+      }
+    }
+  }
+}

--- a/CVCalendar/CVCalendarContentViewController.swift
+++ b/CVCalendar/CVCalendarContentViewController.swift
@@ -134,7 +134,7 @@ extension CVCalendarContentViewController {
 
     public func presentPreviousView(_ view: UIView?) { }
 
-    public func updateDayViews(_ hidden: Bool) { }
+    public func updateDayViews(shouldShow: Bool) { }
 }
 
 // MARK: - Contsant conversion

--- a/CVCalendar/CVCalendarDayView.swift
+++ b/CVCalendar/CVCalendarDayView.swift
@@ -56,13 +56,7 @@ public final class CVCalendarDayView: UIView {
             }
         }
     }
-    
-    public override var isHidden: Bool {
-        didSet {
-            isUserInteractionEnabled = isHidden ? false : true
-        }
-    }
-    
+  
     // MARK: - Private properties
     
     fileprivate var preliminaryView: UIView?

--- a/CVCalendar/CVCalendarMonthContentViewController.swift
+++ b/CVCalendar/CVCalendarMonthContentViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public final class CVCalendarMonthContentViewController: CVCalendarContentViewController {
+public final class CVCalendarMonthContentViewController: CVCalendarContentViewController, CVCalendarContentPresentationCoordinator {
     fileprivate var monthViews: [Identifier : MonthView]
     
     public override init(calendarView: CalendarView, frame: CGRect) {
@@ -237,8 +237,8 @@ public final class CVCalendarMonthContentViewController: CVCalendarContentViewCo
         
     }
     
-    public override func updateDayViews(_ hidden: Bool) {
-        setDayOutViewsVisible(hidden)
+    public override func updateDayViews(shouldShow: Bool) {
+      setDayOutViewsVisible(monthViews: monthViews, visible: shouldShow)
     }
     
     fileprivate var togglingBlocked = false
@@ -357,34 +357,6 @@ extension CVCalendarMonthContentViewController {
         }
     }
     
-    public func setDayOutViewsVisible(_ visible: Bool) {
-        for monthView in monthViews.values {
-            monthView.mapDayViews { dayView in
-                if dayView.isOut {
-                    if !visible {
-                        dayView.alpha = 0
-                        dayView.isHidden = false
-                    }
-                    
-                    UIView.animate(withDuration: 0.5, delay: 0,
-                                   options: UIViewAnimationOptions(),
-                                   animations: {
-                                    dayView.alpha = visible ? 0 : 1
-                    },
-                                   completion: { _ in
-                                    if visible {
-                                        dayView.alpha = 1
-                                        dayView.isHidden = true
-                                        dayView.isUserInteractionEnabled = false
-                                    } else {
-                                        dayView.isUserInteractionEnabled = true
-                                    }
-                    })
-                }
-            }
-        }
-    }
-    
     public func updateSelection() {
         let coordinator = calendarView.coordinator
         if let selected = coordinator?.selectedDayView {
@@ -401,7 +373,7 @@ extension CVCalendarMonthContentViewController {
                 }
             }
         }
-        
+      
         let calendar = self.calendarView.delegate?.calendar?() ?? Calendar.current
 
         if let presentedMonthView = monthViews[presented] {

--- a/CVCalendar/CVCalendarView.swift
+++ b/CVCalendar/CVCalendarView.swift
@@ -324,8 +324,8 @@ extension CVCalendarView {
 // MARK: - Convenience API
 
 extension CVCalendarView {
-    public func changeDaysOutShowingState(_ shouldShow: Bool) {
-        contentController.updateDayViews(shouldShow)
+    public func changeDaysOutShowingState(shouldShow: Bool) {
+        contentController.updateDayViews(shouldShow: shouldShow)
     }
 
     public func toggleViewWithDate(_ date: Foundation.Date) {

--- a/CVCalendar/CVCalendarWeekContentViewController.swift
+++ b/CVCalendar/CVCalendarWeekContentViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public final class CVCalendarWeekContentViewController: CVCalendarContentViewController {
+public final class CVCalendarWeekContentViewController: CVCalendarContentViewController, CVCalendarContentPresentationCoordinator {
     fileprivate var weekViews: [Identifier : WeekView]
     fileprivate var monthViews: [Identifier : MonthView]
 
@@ -231,8 +231,8 @@ public final class CVCalendarWeekContentViewController: CVCalendarContentViewCon
 
     }
 
-    public override func updateDayViews(_ hidden: Bool) {
-        setDayOutViewsVisible(hidden)
+    public override func updateDayViews(shouldShow: Bool) {
+      setDayOutViewsVisible(monthViews: monthViews, visible: shouldShow)
     }
 
     fileprivate var togglingBlocked = false
@@ -407,34 +407,6 @@ extension CVCalendarWeekContentViewController {
     public func prepareTopMarkersOnWeekView(_ weekView: WeekView, hidden: Bool) {
         weekView.mapDayViews { dayView in
             dayView.topMarker?.isHidden = hidden
-        }
-    }
-
-    public func setDayOutViewsVisible(_ visible: Bool) {
-        for monthView in monthViews.values {
-            monthView.mapDayViews { dayView in
-                if dayView.isOut {
-                    if !visible {
-                        dayView.alpha = 0
-                        dayView.isHidden = false
-                    }
-
-                    UIView.animate(withDuration: 0.5, delay: 0,
-                        options: UIViewAnimationOptions(),
-                        animations: {
-                            dayView.alpha = visible ? 0 : 1
-                            },
-                        completion: { _ in
-                            if visible {
-                                dayView.alpha = 1
-                                dayView.isHidden = true
-                                dayView.isUserInteractionEnabled = false
-                            } else {
-                                dayView.isUserInteractionEnabled = true
-                            }
-                    })
-                }
-            }
         }
     }
 


### PR DESCRIPTION
[bugfix] When shouldShowDaysOut is true and earliestSelectableDate is set to a date later than the out days of the previous month the out days are still selectable and colored wrong until the month is changed. To fix I removed the KVO on `isHidden` since `isUserInteractionEnabled` is used to calculate `isDisabled`. I'm not sure if this is the best way to fix it, but in my tests it does fix the issue and doesn't cause any other side effects.
```
public override var isHidden: Bool {
    didSet {
      isUserInteractionEnabled = isHidden ? false : true
    }
}
```

[improvement] I found that a boolean logic was reversed in changeDaysOutShowingState so I used labelled arguments to make it more consistent.

[improvement] I found that there is some duplicate code for setDayOutViewsVisible so I refactored this into a new protocol CVCalendarContentPresentationCoordinator that contains the shared logic applied to any calendar which can toggle the presentation of out days.